### PR TITLE
Allow to specify windows specific path to php-cs-fixer in a different settings property

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ or right mouse context menu `Format Selection`
 ```JSON
 {
     "php-cs-fixer.executablePath": "php-cs-fixer",
+    "php-cs-fixer.executablePathWindows": "php-cs-fixer.bat",
     "php-cs-fixer.onsave": false,
     "php-cs-fixer.rules": "@PSR2",
     "php-cs-fixer.config": ".php_cs",
@@ -48,6 +49,8 @@ or use phar file
 ```JSON
     "php-cs-fixer.executablePath: "/full/path/of/php-cs-fixer.phar"
 ```
+
+You also have `executablePathWindows` available if you want to specify Windows specific path. Useful if you share your workspace settings among different environments.
 
 executablePath can use ${workspaceRoot} as workspace root path.
 

--- a/extension.js
+++ b/extension.js
@@ -18,7 +18,10 @@ class PHPCSFixer {
         this.onsave = config.get('onsave', false);
         this.autoFixByBracket = config.get('autoFixByBracket', true);
         this.autoFixBySemicolon = config.get('autoFixBySemicolon', false);
-        this.executablePath = config.get('executablePath', process.platform === "win32" ? "php-cs-fixer.bat" : "php-cs-fixer");
+        this.executablePath = config.get(
+            'executablePath',
+            process.platform === "win32" ? config.get('executablePathWindows', 'php-cs-fixer.bat') : 'php-cs-fixer'
+        );
         this.executablePath = this.executablePath.replace('${workspaceRoot}', workspace.rootPath);
         this.rules = config.get('rules', '@PSR2');
         this.config = config.get('config', '.php_cs');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
                     "default": "php-cs-fixer",
                     "description": "Points to the php-cs-fixer exectuable, eg: win: php-cs-fixer.bat, other: php-cs-fixer; or points to php-cs-fixer.phar path, eg: /full/path/of/php-cs-fixer.phar"
                 },
+                "php-cs-fixer.executablePathWindows": {
+                    "type": "string",
+                    "default": "php-cs-fixer.bat",
+                    "description": "Points to the php-cs-fixer exectuable on Windows environments, eg: php-cs-fixer.bat. Useful if you are sharing settings among different environments."
+                },
                 "php-cs-fixer.rules": {
                     "type": "string",
                     "default": "@PSR2",


### PR DESCRIPTION
We are sharing our workspace settings with the whole dev team. Some of our developers are on Windows and some are on macOS. This pull request proposes to add `executablePathWindows` setting to allow to specify different path to php-cs-fixer for Windows environment.