### PR TITLE
Feature: enable to set multiple config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or right mouse context menu `Format Selection`
     "php-cs-fixer.executablePathWindows": "",   //eg: php-cs-fixer.bat
     "php-cs-fixer.onsave": false,
     "php-cs-fixer.rules": "@PSR2",
-    "php-cs-fixer.config": ".php_cs",
+    "php-cs-fixer.config": ".php_cs;.php_cs.dist",
     "php-cs-fixer.autoFixByBracket": true,
     "php-cs-fixer.autoFixBySemicolon": false,
     "php-cs-fixer.formatHtml": false,
@@ -69,13 +69,13 @@ you can format html at the same time.
     "php-cs-fixer.formatHtml": true
 ```
 
-You can use config file
+You can use a config file form a list of semicolon separated values
 
 ```JSON
-    "php-cs-fixer.config: ".php_cs"
+    "php-cs-fixer.config: ".php_cs;.php_cs.dist"
 ```
 
-.php_cs can place in workspace root folder or .vscode folder or any other folders:
+config file can place in workspace root folder or .vscode folder or any other folders:
 
 ```JSON
     "php-cs-fixer.config: "/full/config/file/path"

--- a/extension.js
+++ b/extension.js
@@ -37,7 +37,7 @@ class PHPCSFixer {
         if (typeof (this.rules) == 'object') {
             this.rules = JSON.stringify(this.rules);
         }
-        this.config = config.get('config', '.php_cs').replace(/^~\//, os.homedir() + '/');
+        this.config = config.get('config', '.php_cs');
         this.formatHtml = config.get('formatHtml', false);
         this.documentFormattingProvider = config.get('documentFormattingProvider', true);
         this.allowRisky = config.get('allowRisky', false);

--- a/extension.js
+++ b/extension.js
@@ -69,7 +69,7 @@ class PHPCSFixer {
                 // include also {workspace.rootPath}/.vscode/ & {workspace.rootPath}/
                 files = files.concat(
                     configFiles.map(file => rootPath + '/.vscode/' + file),
-                    configFiles.map(file => rootPath + file)
+                    configFiles.map(file => rootPath + '/' + file)
                 );
             }
             for (let i = 0, len = files.length; i < len; i++) {

--- a/extension.js
+++ b/extension.js
@@ -37,7 +37,7 @@ class PHPCSFixer {
         if (typeof (this.rules) == 'object') {
             this.rules = JSON.stringify(this.rules);
         }
-        this.config = config.get('config', '.php_cs');
+        this.config = config.get('config', '.php_cs;.php_cs.dist');
         this.formatHtml = config.get('formatHtml', false);
         this.documentFormattingProvider = config.get('documentFormattingProvider', true);
         this.allowRisky = config.get('allowRisky', false);

--- a/extension.js
+++ b/extension.js
@@ -60,12 +60,17 @@ class PHPCSFixer {
         }
         let useConfig = false;
         if (this.config.length > 0) {
-            let files = [];
-            let r = workspace.rootPath;
-            if (r == undefined) {
-                files = [this.config];
-            } else {
-                files = [this.config, r + '/.vscode/' + this.config, r + '/' + this.config];
+            let rootPath = workspace.rootPath;
+            let configFiles = this.config.split(';') // allow multiple files definitions semicolon separated values
+                .filter(file => '' !== file) // do not include empty definitions
+                .map(file => file.replace(/^~\//, os.homedir() + '/')); // replace ~/ with home dir
+            let files = configFiles;
+            if (rootPath !== undefined) {
+                // include also {workspace.rootPath}/.vscode/ & {workspace.rootPath}/
+                files = files.concat(
+                    configFiles.map(file => rootPath + '/.vscode/' + file),
+                    configFiles.map(file => rootPath + file)
+                );
             }
             for (let i = 0, len = files.length; i < len; i++) {
                 let c = files[i];

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
                 },
                 "php-cs-fixer.config": {
                     "type": "string",
-                    "default": ".php_cs;php_cs.dist",
+                    "default": ".php_cs;.php_cs.dist",
                     "description": "config file (.php_cs, .php_cs.dist or custom defined) can place in workspace root folder or .vscode folder or any other folder (full path)"
                 },
                 "php-cs-fixer.onsave": {

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
                 },
                 "php-cs-fixer.config": {
                     "type": "string",
-                    "description": "config file(.php_cs) can place in workspace root folder or .vscode folder or any other folder(full path)"
                     "default": ".php_cs;php_cs.dist",
+                    "description": "config file (.php_cs, .php_cs.dist or custom defined) can place in workspace root folder or .vscode folder or any other folder (full path)"
                 },
                 "php-cs-fixer.onsave": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
                 },
                 "php-cs-fixer.config": {
                     "type": "string",
-                    "default": ".php_cs",
                     "description": "config file(.php_cs) can place in workspace root folder or .vscode folder or any other folder(full path)"
+                    "default": ".php_cs;php_cs.dist",
                 },
                 "php-cs-fixer.onsave": {
                     "type": "boolean",


### PR DESCRIPTION
This PR allows to specify multiple config files as semicolon separated values in setting `php-cs-fixer.config`.

In this way, this plugin is following the `php-cs-fixer` standard behavior of consider first `.php_cs` and then `.php_cs.dist`.

In the current version the plugin will test if the config file exists for the default value `".php_cs"` (assuming that `workspace.rootPath` is `/home/user/project`) in exactly that order:
1. `.php_cs`
1. `/home/user/project/.vscode/.php_cs`
1. `/home/user/project/.php_cs`

With the PR it will check for:
1. `.php_cs`
1. `.php_cs.dist`
1. `/home/user/project/.vscode/.php_cs`
1. `/home/user/project/.vscode/.php_cs.dist`
1. `/home/user/project/.php_cs`
1. `/home/user/project/.php_cs.dist`


**Changes**

Enable to set multiple config files in setting `php-cs-fixer.config`.

Now default value of `php-cs-fixer.config` is `".php_cs;.php_cs.dist"`.

Other minor change is that the substitution of `"~/mysettings.php"` was expanded to `"/home/user/mysettings.php"` on `loadSettings`. Its is now expanded on `getArgs`.

This PR will not introduce any breaking change since semicolon cannot be used as a name of file previously and if the user have a custom setting the behavior would be exactly the same.

**Testing:**

As this extension does not have any automated test I perform manual test on my machine and it works.

Thanks for your plugin!