### PR TITLE
Fix `exclude` option to work on Windows paths

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -376,7 +376,7 @@ class PHPCSFixer {
 
     isExcluded(document) {
         if (this.exclude.length > 0 && document.uri.scheme == 'file' && !document.isUntitled) {
-            return anymatch(this.exclude, document.fileName);
+            return anymatch(this.exclude, document.uri.path);
         }
         return false;
     }


### PR DESCRIPTION
[`anymatch`](https://www.npmjs.com/package/anymatch), the library used for matching the `php-cs-fixer.exclude` option, does not support Windows-style paths:

> Note: This module has Bash-parity, please be aware that Windows-style backslashes are not supported as separators. See [https://github.com/micromatch/micromatch#backslashes](https://github.com/micromatch/micromatch#backslashes) for more information.

See the suggested changes. Currently `anymatch` is called using [`document.fileName`](https://code.visualstudio.com/api/references/vscode-api#TextDocument), which returns a system-dependent file path, e.g. `C:\Users\alec\Projects\wordpress\themes\my_file.php`. This fails to match against globs in `anymatch`. For example:

*user-settings.json*
```json
{
    "php-cs-fixer.exclude": [
        "**/themes/**"
    ]
}
```

When saving `C:\Users\alec\Projects\wordpress\themes\my_file.php`, the themes folder exclude does not match, since `document.fileName` contains Windows-style backslashes, and the file is still formatted. Given the way anymatch is designed, passing `**\themes\**`, `**\\themes\\**`, or any other variation does not work either.

To fix this, [`document.fileName`](https://code.visualstudio.com/api/references/vscode-api#TextDocument) was changed to [`document.uri.path`](https://code.visualstudio.com/api/references/vscode-api#Uri), which outputs the file path with explicit forward slashes. For example, the file above is formatted as `/c:/Users/alec/Projects/wordpress/themes/my_file.php`. This allows the `php-cs-fixer.exclude` option to work properly with Windows paths.