### PR TITLE
Search for config files in the order specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,16 @@ you can format html at the same time.
 You can use a config file form a list of semicolon separated values
 
 ```JSON
-    "php-cs-fixer.config: ".php_cs;.php_cs.dist"
+    "php-cs-fixer.config": ".php_cs;.php_cs.dist"
 ```
 
 config file can place in workspace root folder or .vscode folder or any other folders:
 
 ```JSON
-    "php-cs-fixer.config: "/full/config/file/path"
+    "php-cs-fixer.config": "/full/config/file/path"
 ```
+
+Relative paths are only considered when a workspace folder is open.
 
 config file .php-cs example
 

--- a/extension.js
+++ b/extension.js
@@ -81,7 +81,7 @@ class PHPCSFixer {
                 ]
             }
 
-            let files = [];
+            const files = [];
             for (const file of configFiles) {
                 if (path.isAbsolute(file)) {
                     files.push(file)

--- a/extension.js
+++ b/extension.js
@@ -71,14 +71,27 @@ class PHPCSFixer {
             let configFiles = this.config.split(';') // allow multiple files definitions semicolon separated values
                 .filter(file => '' !== file) // do not include empty definitions
                 .map(file => file.replace(/^~\//, os.homedir() + '/')); // replace ~/ with home dir
-            let files = configFiles;
+
+            // include also {workspace.rootPath}/.vscode/ & {workspace.rootPath}/
+            let searchPaths = []
             if (rootPath !== undefined) {
-                // include also {workspace.rootPath}/.vscode/ & {workspace.rootPath}/
-                files = files.concat(
-                    configFiles.map(file => rootPath + '/.vscode/' + file),
-                    configFiles.map(file => rootPath + '/' + file)
-                );
+                searchPaths = [
+                    rootPath + '/.vscode/',
+                    rootPath + '/',
+                ]
             }
+
+            let files = [];
+            for (const file of configFiles) {
+                if (path.isAbsolute(file)) {
+                    files.push(file)
+                } else {
+                    for (const searchPath of searchPaths) {
+                        files.push(searchPath + file);
+                    }
+                }
+            };
+
             for (let i = 0, len = files.length; i < len; i++) {
                 let c = files[i];
                 if (fs.existsSync(c)) {


### PR DESCRIPTION
Previously specifying a config like

```JSON
"php-cs-fixer.config": ".php_cs;~/.php_cs",
```

didn't work as expected. Absolute paths always took precedence over relative paths, which means the above would not work, only `~/.php_cs` was ever used.

This PR changes the code to handle relative / absolute paths properly (additionally stopping invalid paths like `/path/to/project/.vscode//path/to/home/.php_cs` from being searched).