### PR TITLE
Fix `__dirname` output

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const path = require('path');
 /**@type {import('webpack').Configuration}*/
 const config = {
 	target: 'node', // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
-
+	node: false, // Prevent NodeStuffPlugin from overriding `__dirname` 📖 -> https://webpack.js.org/configuration/node/
 	entry: './extension.js', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
 	output: {
 		// the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/


### PR DESCRIPTION
Webpack 3 sets `__dirname` to `/` by default when  the target is set to `node`. This was breaking the [default executable path for this plugin](https://github.com/junstyle/vscode-php-cs-fixer/blob/0b0ba04cefa7e133d80f1f0fe416341b66741679/extension.js#L28). 