### PR TITLE
Use ${workspaceFolder} besides ${workspaceRoot}

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}" ],
             "stopOnEntry": false
         },
         {
@@ -15,7 +15,7 @@
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
-            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/test" ],
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}", "--extensionTestsPath=${workspaceFolder}/test" ],
             "stopOnEntry": false
         }
     ]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ or use phar file
 
 You also have `executablePathWindows` available if you want to specify Windows specific path. Useful if you share your workspace settings among different environments.
 
-executablePath can use ${workspaceRoot} as workspace first root folder path.
+executablePath can use ${workspaceFolder} as workspace first root folder path.
 
 [executablePath, executablePathWindows, config] can use "~/" as user home directory on os.
 

--- a/extension.js
+++ b/extension.js
@@ -72,7 +72,9 @@ class PHPCSFixer {
 
     getArgs(fileName) {
         if (workspace.workspaceFolders != undefined) {
-            this.realExecutablePath = this.executablePath.replace('${workspaceRoot}', this.getActiveWorkspacePath() || workspace.workspaceFolders[0].uri.fsPath)
+            // ${workspaceRoot} is depricated
+            const pattern = /^\$\{workspace(Root|Folder)\}/;
+            this.realExecutablePath = this.executablePath.replace(pattern, this.getActiveWorkspacePath() || workspace.workspaceFolders[0].uri.fsPath)
         } else
             this.realExecutablePath = undefined
 

--- a/package.json
+++ b/package.json
@@ -143,8 +143,6 @@
         }
     },
     "scripts": {
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test",
         "vscode:prepublish": "npm update && node ./download-phar.js"
     },
     "devDependencies": {


### PR DESCRIPTION
`${workspaceRoot}` has been deprecated in favour of `${workspaceFolder}`. This PR replaces both when compiling the executable path for php-cs-fixer for backward compatibility.

I also took the liberty to remove the `test` and `postinstall` npm scripts because both were not working and are seemingly unneeded - the project has no tests.