### PR TITLE
Replace deprecated rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ return (new PhpCsFixer\Config())
             ]
         ],
         // 'blank_line_after_opening_tag' => true,
-        // 'blank_line_before_return' => true,
+        // 'blank_line_before_statement' => true,
         'braces' => [
             'allow_single_line_closure' => true,
         ],
@@ -175,7 +175,7 @@ return (new PhpCsFixer\Config())
         // 'phpdoc_trim' => true,
         // 'phpdoc_types' => true,
         // 'phpdoc_var_without_name' => true,
-        // 'pre_increment' => true,
+        // 'increment_style' => true,
         // 'return_type_declaration' => true,
         // 'self_accessor' => true,
         // 'short_scalar_cast' => true,


### PR DESCRIPTION
Hello,

It replaces two removed rules (removed since php cs fixer 2.16.10) which crash the extension if we use (uncomment) them.
Source : https://mlocati.github.io/php-cs-fixer-configurator/#version:2.16|configurator

```
blank_line_before_return -> blank_line_before_statement
pre_increment -> increment_style
```