### PR TITLE
Added a passage to README how to set default formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@ return (new PhpCsFixer\Config())
 ;
 ```
 
+If you have installed other PHP related extensions to VS Code it may happen that
+another formatter is used per default. You can force this extension to be used
+per default by adding this to your settings:
+
+```JSON
+    "[php]": {
+        "editor.defaultFormatter": "junstyle.php-cs-fixer"
+    }
+```
+
+
 ## Auto fix
 
 ```text


### PR DESCRIPTION
I am using the VS Code extension "PHP Tools", which comes with its own formatter and was set as default. That's why the php-cs-fixer had no effect.

After adding 
```json
    "[php]": {
        "editor.defaultFormatter": "junstyle.php-cs-fixer"
    },
```
to the settings, it worked.

So i suggest adding this information to the README ;-)