### PR TITLE
[fix] ignorePHPVersion in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or right mouse context menu on explorer `php-cs-fixer: fix`
     "php-cs-fixer.config": ".php-cs-fixer.php;.php-cs-fixer.dist.php;.php_cs;.php_cs.dist",
     "php-cs-fixer.allowRisky": false,
     "php-cs-fixer.pathMode": "override",
-    "ignorePHPVersion": false,
+    "php-cs-fixer.ignorePHPVersion": false,
     "php-cs-fixer.exclude": [],
     "php-cs-fixer.autoFixByBracket": true,
     "php-cs-fixer.autoFixBySemicolon": false,


### PR DESCRIPTION
## Why
Configure about `"ignorePHPVersion": false,` is incorrect in README.md,  I think.

## What
Add prefix `php-cs-fixer` to `ignorePHPVersion`.

## Test(QA)
- [x] After fix, setting `"php-cs-fixer.ignorePHPVersion"`  is working in VSCode. (Before desc is not working)