### PR TITLE
fix: child_process.spawn() breaking api change in VS Code update 1.92.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,8 +165,6 @@ class PHPCSFixer extends PHPCSFixerConfig {
     }
     args.push(filePath)
 
-    console.log(args)
-    output(JSON.stringify(args, null, 2))
     return args
   }
 


### PR DESCRIPTION
This fixes #212, the VS Code update 1.92.0 breaking api change regarding child_process.spawn(). I took the liberty to output more data from the runAsync() function, to make debugging easier.

* I have tested this on Windows. 
* This PR is not tested against Linux. I have no access to a Linux installation of VS Code.
* I could not test point 3 "If the batch script path may contain spaces, you will also need to wrap the path in quotation marks." of https://github.com/junstyle/vscode-php-cs-fixer/issues/212#issue-2402024749. Because my full path to php-cs-fixer.bat has no spaces inside it `C:\Users\Mirco\AppData\Roaming\Composer\vendor\bin\php-cs-fixer.bat`

After this PR, the output shows:
![image](https://github.com/user-attachments/assets/6f219d50-fe34-47ed-a6fb-f949c03aeaf0)

P.s. if you want to show to original breaking api change error, change line 5 of the runAsync.ts in this PR to
`const cpOptions = Object.assign({}, options /*, { shell: true, } */)`, commenting out the added `shell: true`. The output of the breaking api change then shows:
![image](https://github.com/user-attachments/assets/d8a7c4b2-9bf7-46e3-8096-a65f43c309ed)
